### PR TITLE
Utilize Texture2DArray for texture atlasing

### DIFF
--- a/assets/shaders/default.frag
+++ b/assets/shaders/default.frag
@@ -1,6 +1,5 @@
 #version 450 core
 
-flat in uint animated;
 flat in uint textureIndex;
 
 in float vert_lighting;
@@ -9,12 +8,10 @@ in vec2 vert_uv;
 
 out vec4 color;
 
-uniform vec2 textureAnimation = vec2(0);
 uniform sampler2DArray atlas;
 
 void main() {
-    vec2 uv = vert_uv + textureAnimation * animated;
-    vec4 texture = texture(atlas, vec3(uv, textureIndex));
+    vec4 texture = texture(atlas, vec3(vert_uv, textureIndex));
     if (texture.a < 0.01f) discard;
 
     color = vec4(texture.xyz * vert_lighting, texture.w);

--- a/assets/shaders/default.frag
+++ b/assets/shaders/default.frag
@@ -9,11 +9,11 @@ in vec2 vert_uv;
 out vec4 color;
 
 uniform vec2 textureAnimation = vec2(0);
-uniform sampler2D atlas;
+uniform sampler2DArray atlas;
 
 void main() {
     vec2 uv = vert_uv + textureAnimation * animated;
-    vec4 texture = texture(atlas, uv / 16);
+    vec4 texture = texture(atlas, vec3(uv / 16, 0));
     if (texture.a < 0.01f) discard;
 
     color = vec4(texture.xyz * vert_lighting, texture.w);

--- a/assets/shaders/default.frag
+++ b/assets/shaders/default.frag
@@ -1,6 +1,7 @@
 #version 450 core
 
 flat in uint animated;
+flat in uint textureIndex;
 
 in float vert_lighting;
 in vec3 vert_pos;
@@ -13,7 +14,7 @@ uniform sampler2DArray atlas;
 
 void main() {
     vec2 uv = vert_uv + textureAnimation * animated;
-    vec4 texture = texture(atlas, vec3(uv / 16, 0));
+    vec4 texture = texture(atlas, vec3(uv, textureIndex));
     if (texture.a < 0.01f) discard;
 
     color = vec4(texture.xyz * vert_lighting, texture.w);

--- a/assets/shaders/default.vert
+++ b/assets/shaders/default.vert
@@ -12,18 +12,18 @@ out vec3 vert_pos;
 out vec2 vert_uv;
 
 void main() {
-    animated = (vertexData >> 27) & 1u;
+    animated = bitfieldExtract(vertexData, 27, 1);
 
-    uint yPos = vertexData & 0x1ffu;
-    uint xPos = (vertexData >> 9) & 0x1fu;
-    uint zPos = (vertexData >> 14) & 0x1fu;
+    uint yPos = bitfieldExtract(vertexData,  0, 9);
+    uint xPos = bitfieldExtract(vertexData,  9, 5);
+    uint zPos = bitfieldExtract(vertexData, 14, 5);
     vert_pos = vec3(xPos, yPos, zPos);
 
-    uint xUv = (vertexData >> 19) & 0xfu;
-    uint yUv = (vertexData >> 23) & 0xfu;
+    uint xUv = bitfieldExtract(vertexData, 19, 4);
+    uint yUv = bitfieldExtract(vertexData, 23, 4);
     vert_uv = vec2(xUv, yUv);
 
-    uint occlusionLevel = (vertexData >> 29) & 3u;
+    uint occlusionLevel = bitfieldExtract(vertexData, 29, 2);
     vert_lighting = 0.75f + 0.08f * occlusionLevel;
     gl_Position = MVP * vec4(vert_pos, 1);
 }

--- a/assets/shaders/default.vert
+++ b/assets/shaders/default.vert
@@ -6,21 +6,23 @@ uniform mat4 MVP = mat4(1);
 uniform vec3 lightDirection = vec3(1, 1, 1);
 
 flat out uint animated;
+flat out uint textureIndex;
 
 out float vert_lighting;
 out vec3 vert_pos;
 out vec2 vert_uv;
 
 void main() {
-    animated = bitfieldExtract(vertexData, 27, 1);
+    textureIndex = bitfieldExtract(vertexData, 20, 8);
+    animated = bitfieldExtract(vertexData, 28, 1);
 
     uint yPos = bitfieldExtract(vertexData,  0, 9);
     uint xPos = bitfieldExtract(vertexData,  9, 5);
     uint zPos = bitfieldExtract(vertexData, 14, 5);
     vert_pos = vec3(xPos, yPos, zPos);
 
-    uint xUv = bitfieldExtract(vertexData, 19, 4);
-    uint yUv = bitfieldExtract(vertexData, 23, 4);
+    uint xUv = bitfieldExtract(vertexData, 19, 1);
+    uint yUv = bitfieldExtract(vertexData, 20, 1);
     vert_uv = vec2(xUv, yUv);
 
     uint occlusionLevel = bitfieldExtract(vertexData, 29, 2);

--- a/assets/shaders/default.vert
+++ b/assets/shaders/default.vert
@@ -4,8 +4,8 @@ layout(location = 0) in uint vertexData;
 
 uniform mat4 MVP = mat4(1);
 uniform vec3 lightDirection = vec3(1, 1, 1);
+uniform uint textureAnimation = 0u;
 
-flat out uint animated;
 flat out uint textureIndex;
 
 out float vert_lighting;
@@ -13,8 +13,9 @@ out vec3 vert_pos;
 out vec2 vert_uv;
 
 void main() {
-    textureIndex = bitfieldExtract(vertexData, 20, 8);
-    animated = bitfieldExtract(vertexData, 28, 1);
+    uint animated = bitfieldExtract(vertexData, 28, 1);
+
+    textureIndex = bitfieldExtract(vertexData, 20, 8) + textureAnimation * animated;
 
     uint yPos = bitfieldExtract(vertexData,  0, 9);
     uint xPos = bitfieldExtract(vertexData,  9, 5);

--- a/assets/shaders/outline.vert
+++ b/assets/shaders/outline.vert
@@ -8,13 +8,13 @@ out vec3 vert_pos;
 out vec2 vert_uv;
 
 void main() {
-    uint yPos = vertexData & 0x1ffu;
-    uint xPos = (vertexData >> 9) & 0x1fu;
-    uint zPos = (vertexData >> 14) & 0x1fu;
+    uint yPos = bitfieldExtract(vertexData,  0, 9);
+    uint xPos = bitfieldExtract(vertexData,  9, 5);
+    uint zPos = bitfieldExtract(vertexData, 14, 5);
     vert_pos = vec3(xPos, yPos, zPos);
 
-    uint xUv = (vertexData >> 19) & 0x0fu;
-    uint yUv = (vertexData >> 23) & 0x0fu;
+    uint xUv = bitfieldExtract(vertexData, 19, 4);
+    uint yUv = bitfieldExtract(vertexData, 23, 4);
     vert_uv = vec2(xUv, yUv);
 
     gl_Position = MVP * vec4(vert_pos, 1);

--- a/assets/shaders/outline.vert
+++ b/assets/shaders/outline.vert
@@ -13,8 +13,8 @@ void main() {
     uint zPos = bitfieldExtract(vertexData, 14, 5);
     vert_pos = vec3(xPos, yPos, zPos);
 
-    uint xUv = bitfieldExtract(vertexData, 19, 4);
-    uint yUv = bitfieldExtract(vertexData, 23, 4);
+    uint xUv = bitfieldExtract(vertexData, 19, 1);
+    uint yUv = bitfieldExtract(vertexData, 20, 1);
     vert_uv = vec2(xUv, yUv);
 
     gl_Position = MVP * vec4(vert_pos, 1);

--- a/src/AssetManager/AssetManager.h
+++ b/src/AssetManager/AssetManager.h
@@ -9,6 +9,7 @@
 #include "ShaderProgramRegistry.h"
 #include "ShaderRegistry.h"
 #include "TextRegistry.h"
+#include "TextureArrayRegistry.h"
 #include "TextureRegistry.h"
 
 class AssetManager {
@@ -17,6 +18,7 @@ class AssetManager {
   TextRegistry textRegistry;
   ImageRegistry imageRegistry;
   TextureRegistry textureRegistry;
+  TextureArrayRegistry textureArrayRegistry;
   CubeMapRegistry cubeMapRegistry;
   ShaderRegistry shaderRegistry;
   ShaderProgramRegistry shaderProgramRegistry;
@@ -37,6 +39,10 @@ public:
   Ref<const std::string> loadText(const std::string &name) { return textRegistry.get(name); };
   Ref<const Image> loadImage(const std::string &name) { return imageRegistry.get(name); };
   Ref<const Texture> loadTexture(const std::string &name) { return textureRegistry.get(name); };
+
+
+  /// the expected input format: width;height;
+  Ref<const Texture> loadTextureArray(const std::string &name) { return textureArrayRegistry.get(name); };
 
   /// the expected input format: right;left;top;bottom;front;back
   Ref<const Texture> loadCubeMap(const std::string &name) { return cubeMapRegistry.get(name); };

--- a/src/AssetManager/TextureArrayRegistry.h
+++ b/src/AssetManager/TextureArrayRegistry.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "../Rendering/Texture.h"
+#include "AssetRegistry.h"
+
+class TextureArrayRegistry : public AssetRegistry<Texture> {
+  Ref<const Texture> loadAsset(const std::string& name) override { return Texture::loadTexture2DArray(name); }
+};

--- a/src/Rendering/BlockVertex.cpp
+++ b/src/Rendering/BlockVertex.cpp
@@ -33,7 +33,7 @@ void BlockVertex::offset(uint32_t x, uint32_t y, uint32_t z) {
 }
 
 void BlockVertex::setAnimated() {
-  data |= 0b1 << 27;
+  data |= 0b1 << 28;
 }
 
 glm::ivec3 BlockVertex::getPosition() const {

--- a/src/Rendering/BlockVertex.cpp
+++ b/src/Rendering/BlockVertex.cpp
@@ -1,18 +1,25 @@
 #include "BlockVertex.h"
 
-BlockVertex::BlockVertex(const glm::ivec3& position, const glm::ivec2& uv) {
+BlockVertex::BlockVertex(const glm::ivec3& position, const glm::bvec2& uv) {
   offset(position.x, position.y, position.z);
-  offsetUv(uv.x, uv.y);
+  setUv(uv.x, uv.y);
 }
 
-void BlockVertex::offsetUv(uint8_t x, uint8_t y) {
-  assert(x < 16 && "Coordinate is out of bounds");
-  assert(y < 16 && "Coordinate is out of bounds");
-
-  uint8_t uv = x | (y << 4);
+void BlockVertex::setUv(bool x, bool y) {
+  uint8_t uv = x | (y << 1);
   assert((((data >> 19) & 0xff) + uv) <= 0xff && "UV Coordinates are out of bounds");
 
   data += uv << 19;
+};
+
+void BlockVertex::setTexture(uint8_t x, uint8_t y) {
+  assert(x < 16 && "Coordinate is out of bounds");
+  assert(y < 16 && "Coordinate is out of bounds");
+
+  uint16_t uv = x | (y << 4);
+  assert(uv <= 0xff && "Texture index is out of bounds");
+
+  data += uv << 20;
 };
 
 void BlockVertex::offset(uint32_t x, uint32_t y, uint32_t z) {
@@ -41,67 +48,67 @@ void BlockVertex::setOcclusionLevel(uint8_t occlusionLevel) {
 void BlockVertex::setType(const glm::ivec3& offset, BlockData::BlockType type) {
   switch (type) {
     case BlockData::BlockType::bedrock:
-      offsetUv(1, 1);
+      setTexture(1, 1);
       break;
     case BlockData::BlockType::planks:
-      offsetUv(4, 0);
+      setTexture(4, 0);
       break;
     case BlockData::BlockType::water:
       setAnimated();
-      offsetUv(13, 12);
+      setTexture(13, 12);
       break;
     case BlockData::BlockType::lava:
       setAnimated();
-      offsetUv(13, 14);
+      setTexture(13, 14);
       break;
     case BlockData::BlockType::iron:
-      offsetUv(6, 1);
+      setTexture(6, 1);
       break;
     case BlockData::BlockType::diamond:
-      offsetUv(8, 1);
+      setTexture(8, 1);
       break;
     case BlockData::BlockType::gold:
-      offsetUv(7, 1);
+      setTexture(7, 1);
       break;
     case BlockData::BlockType::obsidian:
-      offsetUv(5, 2);
+      setTexture(5, 2);
       break;
     case BlockData::BlockType::sponge:
-      offsetUv(0, 3);
+      setTexture(0, 3);
       break;
     case BlockData::BlockType::grass:
       if (offset.y == 1) {
-        offsetUv(0, 0);
+        setTexture(0, 0);
       } else if (offset.y == -1) {
-        offsetUv(2, 0);
+        setTexture(2, 0);
       } else {
-        offsetUv(3, 0);
+        setTexture(3, 0);
       }
       break;
     case BlockData::BlockType::dirt:
-      offsetUv(2, 0);
+      setTexture(2, 0);
       break;
     case BlockData::BlockType::sand:
-      offsetUv(2, 1);
+      setTexture(2, 1);
       break;
     case BlockData::BlockType::stone:
-      offsetUv(1, 0);
+      setTexture(1, 0);
       break;
     case BlockData::BlockType::cobblestone:
-      offsetUv(0, 1);
+      setTexture(0, 1);
       break;
     case BlockData::BlockType::glass:
-      offsetUv(1, 3);
+      setTexture(1, 3);
       break;
     case BlockData::BlockType::oak_wood:
       if (offset.y == 1 || offset.y == -1) {
-        offsetUv(5, 1);
+        setTexture(5, 1);
       } else {
-        offsetUv(4, 1);
+        setTexture(4, 1);
       }
       break;
     case BlockData::BlockType::oak_leaves:
-      offsetUv(4, 3);
+      setTexture(4, 3);
       break;
     case BlockData::BlockType::air:
       assert(false);

--- a/src/Rendering/BlockVertex.h
+++ b/src/Rendering/BlockVertex.h
@@ -6,23 +6,24 @@
 
 /**
  * Data layout:
- *  00-09: y  coordinates
- *  09-14: x  coordinates
- *  14-19: z  coordinates
- *  19-27: uv coordinates
- *  27-28: animation flag
- *  28-29: reserved
- *  29-32: normals
+ *  00-08: y  coordinates
+ *  09-13: x  coordinates
+ *  14-18: z  coordinates
+ *  19-20: uv coordinates
+ *  20-27: texture index
+ *  28-28: animation flag
+ *  29-31: normals
  */
 class BlockVertex {
 private:
   uint32_t data = 0;
 
-  void offsetUv(uint8_t x, uint8_t y);
+  void setUv(bool x, bool y);
+  void setTexture(uint8_t x, uint8_t y);
 
 public:
   BlockVertex() = default;
-  BlockVertex(const glm::ivec3& position, const glm::ivec2& uv);
+  BlockVertex(const glm::ivec3& position, const glm::bvec2& uv);
 
   void offset(uint32_t x, uint32_t y, uint32_t z);
   void setAnimated();

--- a/src/Rendering/BlockVertex.h
+++ b/src/Rendering/BlockVertex.h
@@ -12,7 +12,8 @@
  *  19-20: uv coordinates
  *  20-27: texture index
  *  28-28: animation flag
- *  29-31: normals
+ *  29-30: occlusion
+ *  31-31: reserved
  */
 class BlockVertex {
 private:

--- a/src/Rendering/Image.cpp
+++ b/src/Rendering/Image.cpp
@@ -1,0 +1,19 @@
+#include "Image.h"
+
+#include <span>
+
+Image Image::subImage(glm::uvec2 offset, glm::uvec2 extent) const {
+  assert((offset.x + extent.x) <= width && (offset.y + extent.y) <= height);
+
+  Image NewImage{extent.x, extent.y};
+  const uint32_t RowPitch = width * sizeof(uint32_t);
+  for (uint32_t y = 0; y < extent.y; ++y) {
+    const size_t SrcOffset = ((offset.y + y) * RowPitch) + (offset.x * sizeof(uint32_t));
+
+    const auto SourceRow = std::span<const std::uint8_t>(data.data() + SrcOffset, extent.x * sizeof(uint32_t));
+
+    NewImage.data.insert(NewImage.data.begin(), SourceRow.begin(), SourceRow.end());
+  }
+
+  return NewImage;
+}

--- a/src/Rendering/Image.h
+++ b/src/Rendering/Image.h
@@ -5,4 +5,6 @@
 struct Image {
   uint32_t width, height;
   std::vector<uint8_t> data;
+
+  Image subImage(glm::uvec2 offset, glm::uvec2 extent) const;
 };

--- a/src/Rendering/ShaderProgram.cpp
+++ b/src/Rendering/ShaderProgram.cpp
@@ -46,6 +46,10 @@ void ShaderProgram::setInt(const std::string &location, int32_t value) const {
   glProgramUniform1i(shaderProgram, getUniformLocation(location), value);
 }
 
+void ShaderProgram::setUInt(const std::string &location, int32_t value) const {
+  glProgramUniform1ui(shaderProgram, getUniformLocation(location), value);
+}
+
 void ShaderProgram::setFloat(const std::string &location, float value) const {
   glProgramUniform1f(shaderProgram, getUniformLocation(location), value);
 }

--- a/src/Rendering/ShaderProgram.h
+++ b/src/Rendering/ShaderProgram.h
@@ -17,6 +17,7 @@ public:
   void bind() const;
 
   void setInt(const std::string &location, int32_t value) const;
+  void setUInt(const std::string &location, int32_t value) const;
   void setFloat(const std::string &location, float value) const;
   void setVec2(const std::string &location, const glm::vec2 &value) const;
   void setVec3(const std::string &location, const glm::vec3 &value) const;

--- a/src/Rendering/Texture.cpp
+++ b/src/Rendering/Texture.cpp
@@ -4,7 +4,7 @@
 #include "Image.h"
 
 Texture::Texture(uint32_t image_type, int32_t maxLod) : type(image_type) {
-  assert(type == GL_TEXTURE_2D || type == GL_TEXTURE_CUBE_MAP);
+  assert(type == GL_TEXTURE_2D || type == GL_TEXTURE_2D_ARRAY || type == GL_TEXTURE_CUBE_MAP);
   glGenTextures(1, &id);
   bind();
 
@@ -36,7 +36,24 @@ void Texture::buffer2DRGBAData(const Image& image) {
   unbind();
 }
 
-void Texture::bufferCubeMapRGBAData(const std::array<Ref<const Image>, 6>& images) {
+void Texture::buffer2DArrayRGBAData(std::span<const Image> images) {
+  assert(type == GL_TEXTURE_2D_ARRAY);
+  assert(images.size() > 0);
+  bind();
+
+  glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_RGBA, static_cast<int32_t>(images[0].width),
+               static_cast<int32_t>(images[0].height), images.size(), 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+
+  for (size_t i = 0; i < images.size(); i++) {
+    glTexSubImage3D(GL_TEXTURE_2D_ARRAY, 0, 0, 0, i, static_cast<int32_t>(images[i].width),
+                    static_cast<int32_t>(images[i].height), 1, GL_RGBA, GL_UNSIGNED_BYTE, images[i].data.data());
+  }
+  glGenerateMipmap(type);
+
+  unbind();
+}
+
+void Texture::bufferCubeMapRGBAData(std::span<Ref<const Image>, 6> images) {
   assert(type == GL_TEXTURE_CUBE_MAP);
   bind();
 
@@ -70,6 +87,28 @@ Ref<const Texture> Texture::loadTexture2D(const std::string& name) {
 
   Ref<Texture> texture = std::make_shared<Texture>(GL_TEXTURE_2D, 4);
   texture->buffer2DRGBAData(*image);
+  return texture;
+}
+
+Ref<const Texture> Texture::loadTexture2DArray(const std::string& name) {
+  Ref<const Image> image = AssetManager::instance().loadImage(name);
+  if (image == nullptr) {
+    return nullptr;
+  }
+
+  // Split up image
+  // Assume 16x16 splits
+  const uint8_t tileWidth = 16;
+  const uint8_t tileHeight = 16;
+  std::vector<Image> subImages;
+  for (uint32_t tileY = 0; tileY < image->height / tileHeight; ++tileY) {
+    for (uint32_t tileX = 0; tileX < image->width / tileWidth; ++tileX) {
+      subImages.emplace_back(image->subImage({tileX * tileWidth, tileY * tileHeight}, {tileWidth, tileHeight}));
+    }
+  }
+
+  Ref<Texture> texture = std::make_shared<Texture>(GL_TEXTURE_2D_ARRAY, 4);
+  texture->buffer2DArrayRGBAData(subImages);
   return texture;
 }
 

--- a/src/Rendering/Texture.h
+++ b/src/Rendering/Texture.h
@@ -18,9 +18,11 @@ public:
   void unbind() const;
 
   void buffer2DRGBAData(const Image& image);
-  void bufferCubeMapRGBAData(const std::array<Ref<const Image>, 6>& images);
+  void buffer2DArrayRGBAData(std::span<const Image> images);
+  void bufferCubeMapRGBAData(std::span<Ref<const Image>, 6> images);
 
   static Ref<const Texture> loadTexture2D(const std::string& name);
+  static Ref<const Texture> loadTexture2DArray(const std::string& name);
   static Ref<const Texture> loadCubeMapTexture(const std::string& name);
 
   Texture(const Texture&) = delete;

--- a/src/World/World.cpp
+++ b/src/World/World.cpp
@@ -4,7 +4,7 @@
 
 World::World(const Ref<Persistence>& persistence, int32_t seed) : persistence(persistence), generator(seed) {
   shader = AssetManager::instance().loadShaderProgram("assets/shaders/default");
-  setTextureAtlas(AssetManager::instance().loadTexture("assets/textures/default_texture.png"));
+  setTextureAtlas(AssetManager::instance().loadTextureArray("assets/textures/default_texture.png"));
 }
 
 Ref<Chunk> World::generateOrLoadChunk(glm::ivec2 position) {

--- a/src/World/World.cpp
+++ b/src/World/World.cpp
@@ -75,14 +75,14 @@ void World::render(glm::vec3 playerPos, glm::mat4 transform) {
   std::sort(sortedChunkIndices->begin(), sortedChunkIndices->end(),
             [](const auto& a, const auto& b) { return b.second < a.second; });
 
-  glm::vec2 animation{0};
-  int32_t animationProgress = static_cast<int32_t>(textureAnimation) % 5;
+  const int32_t animationProgress = static_cast<int32_t>(textureAnimation) % 5;
 
-  if (animationProgress != 0) {
-    animation = glm::vec2(2 - (animationProgress % 2), (animationProgress - 1) / 2);
-  }
+  // animation offsets for water and lava
+  const static int32_t animationOffsets[] = {0, 1, 2, 17, 18};
 
-  shader->setVec2("textureAnimation", animation);
+  const int32_t animationOffset = animationOffsets[animationProgress];
+
+  shader->setUInt("textureAnimation", animationOffset);
   glEnable(GL_BLEND);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 

--- a/src/glCraft.h
+++ b/src/glCraft.h
@@ -30,6 +30,7 @@
 #include <optional>
 #include <random>
 #include <set>
+#include <span>
 #include <sstream>
 #include <string>
 #include <tuple>


### PR DESCRIPTION
Hey there.

Since this repository is intended to be educational, I figured I'd contribute what an implementation that utilizes 2D texture-arrays looks like.

![qrenderdoc_Jw0iXfEkfY](https://user-images.githubusercontent.com/644247/180123468-1b532f5c-4ffd-4e9f-98ed-8f4efc13c61a.gif)

This PR implements the Minecraft 2d texture atlas image as a `GL_TEXTURE_2D_ARRAY` rather than a regular `GL_TEXTURE_2D` to allow for much of the 2D texture look-up arithmetic to reduce down into singular integer values. This also allows for better sampling behavior(allows filtering, wrapping, anisotropy, etc), mip-map behavior(no bleeding pixels), and allows for features such as animated textures to be much more trivial(just an integer-index offset is needed to pick which image you want to sample).

Here are some links about Texture2DArrays
https://www.khronos.org/opengl/wiki/Array_Texture
https://docs.unity3d.com/ScriptReference/Texture2DArray.html

I've changed the encoding of bits for each vertex a bit. There are some next steps after this to better-utilize the bits as this needs an additional 2 extra bits of data(8-bit texture index and 2-bit UV). The next step after this one would be to encode or derive the direction that the triangle is facing such that the UV can be derived from lowest bit set from the world-position(and determining which pair of XYZ should be sampled). Which I have some ideas for.